### PR TITLE
Fixed a race condition in ExecuteOrTrajectory

### DIFF
--- a/src/OWDController.cpp
+++ b/src/OWDController.cpp
@@ -246,10 +246,7 @@ bool OWDController::ExecuteORTrajectory(OpenRAVE::TrajectoryBaseConstPtr traj)
         return false;
     }
 
-    // TODO: We need to add a time_added field to avoid a race condition here.
-    //execution_time_ = response.time_added;
-    execution_time_ = ros::Time::now();
-
+    execution_time_ = response.time_added;
     status_cleared_ = false;
     return true;
 }


### PR DESCRIPTION
This modifies ExecuteOrTrajectory to use the time_added value in the `owd_msgs/AddOrTrajectory` service response, instead of the current `ros::Time::now`. This avoids a race condition that may cause `IsDone` to prematurely return "true" due to small differences in ROS time.
